### PR TITLE
Extend tests: with flushing Hibernate Session after update B

### DIFF
--- a/src/main/java/ru/problem/controller/ControllerRequest.java
+++ b/src/main/java/ru/problem/controller/ControllerRequest.java
@@ -22,6 +22,8 @@ public class ControllerRequest {
     private boolean withNative = true;
     @Builder.Default
     private long bId = 1;
+    @Builder.Default
+    private boolean flushInsideB = false;
 
     @SuppressWarnings("WeakerAccess")
     public Map<String, List<String>> toParams() {
@@ -31,6 +33,7 @@ public class ControllerRequest {
         }
         params.put("withNative", singletonList(String.valueOf(isWithNative())));
         params.put("bId", singletonList(String.valueOf(getBId())));
+        params.put("flushInsideB", singletonList(String.valueOf(isFlushInsideB())));
         return params;
     }
 }

--- a/src/main/java/ru/problem/dao/TstBRepository.java
+++ b/src/main/java/ru/problem/dao/TstBRepository.java
@@ -1,7 +1,7 @@
 package ru.problem.dao;
 
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
 import ru.problem.model.TstB;
 
-public interface TstBRepository extends CrudRepository<TstB, Long> {
+public interface TstBRepository extends JpaRepository<TstB, Long> {
 }

--- a/src/main/java/ru/problem/service/TstAService.java
+++ b/src/main/java/ru/problem/service/TstAService.java
@@ -28,10 +28,12 @@ public class TstAService {
     public void save(ControllerRequest request) {
         TstA tstA = TstA.builder().name(LocalDateTime.now().toString()).build();
 
-        bService.updateTstsB(request.getBId()); //update TstB (findById+save) @Transactional
+        bService.updateTstsB(request.getBId(), request.isFlushInsideB()); //update TstB (findById+save) @Transactional
+
         if (request.isWithNative()) {
             cService.executeNative(); // native query 'select 1' @Transactional
         }
+
         repository.save(tstA); // insert TstA @Transactional
 
         //emulate long slow transaction if requested

--- a/src/main/java/ru/problem/service/TstBService.java
+++ b/src/main/java/ru/problem/service/TstBService.java
@@ -20,12 +20,15 @@ public class TstBService {
     }
 
     @Transactional
-    public void updateTstsB(long id) {
+    public void updateTstsB(long id, boolean flush) {
         TstB tstB = repository.findById(id).get();
         Long value = tstB.getValue();
         log.info("Value = {}", value);
         tstB.setValue(++value);
         repository.save(tstB);
+        if (flush) {
+            repository.flush();
+        }
     }
 }
 

--- a/src/test/java/ru/problem/controller/ControllerTest.java
+++ b/src/test/java/ru/problem/controller/ControllerTest.java
@@ -159,4 +159,31 @@ public class ControllerTest {
             assertThat(fast.getThread()).isNotEqualTo(slow.getThread());
         });
     }
+
+    @Test//Flaky
+    public void testSlowBeforeFast_withFlushInsideB_onSameB() throws InterruptedException {
+        Duration sleep = Duration.ofSeconds(1);
+        testSlowBeforeFast(sleep, req -> req.bId(1).flushInsideB(true), (slow, fast) -> {
+            //Slow must be slow
+            assertThat(slow.getDuration()).isGreaterThanOrEqualTo(sleep);
+            //todo Fast must be fast but it is slow too
+            assertThat(fast.getDuration()).isGreaterThanOrEqualTo(sleep);
+            //But they works on different threads
+            assertThat(fast.getThread()).isNotEqualTo(slow.getThread());
+        });
+    }
+
+    @Test
+    public void testSlowBeforeFast_withFlushInsideB_onDifferentB() throws InterruptedException {
+        Duration sleep = Duration.ofSeconds(1);
+        AtomicLong bId = new AtomicLong(1);
+        testSlowBeforeFast(sleep, req -> req.bId(bId.getAndIncrement()).flushInsideB(true), (slow, fast) -> {
+            //Slow must be slow
+            assertThat(slow.getDuration()).isGreaterThanOrEqualTo(sleep);
+            //Fast must be fast and it is fast
+            assertThat(fast.getDuration()).isLessThanOrEqualTo(sleep);
+            //But they works on different threads
+            assertThat(fast.getThread()).isNotEqualTo(slow.getThread());
+        });
+    }
 }


### PR DESCRIPTION
Дело, похоже, всё таки в работе внутреннего кэша Hibernate и его сброса в БД.

Когда у нас нет нативных запросов, явных `flush` или `saveAndFlush` то твоё обновление сущности `B` не идёт в БД, а остаётся известным только текущей `Session` хибера.
А если БД не знает об обновлении записи, то и блокировки нет.
Более того, если в БД, фактически, сначала прилетят SQL-запросы второго `быстрого` запроса, он без проблем выполнится (взяв и отпустив блокировку), а уже потом прилетят SQL-запросы первого `медленного` запроса, которые отработают быстро так как блокировки на обновление уже нет.

Если же в дело включается нативный запрос или, уж тем более, явные `flush` сессии, то БД уже узнаёт о попытке обновления записи первым `медленным` запросом и блокирует вторую `быструю` транзакцию.
В данном случае в БД первую очередь попадают SQL-запросы от первой транзакции и взводится блокировка на обновление, а вторая транзакция просто упирается в эту блокировку и ожидает завершения первой транзакции.

Ровно по этому и нет замедления `быстрого` запроса если мы обновляем **разные** строки в `B`: нам блокировка одной строки не мешает обновлять другую.